### PR TITLE
Ignore currency.json (currency conversion cache)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-src/data/GeoLite2-Country.mmdb
+src/data
 src/__pycache__/
 *.pyc
 .vscode/*


### PR DESCRIPTION
The website saves a cache of the API response from fixer.io into the data dir. This file is now ignored.